### PR TITLE
Add string include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
 
 
   build_and_test_mac:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
       - name: Checkout wren-console
         uses: actions/checkout@v2

--- a/src/cli/cli.c
+++ b/src/cli/cli.c
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "vm.h"
 #include "cli.h"
 


### PR DESCRIPTION
In
https://github.com/exercism/wren/actions/runs/6704346582/job/18216581167?pr=137
I noticed the warnings

```
../../src/cli/cli.c: In function ‘setRootDirectory’:
../../src/cli/cli.c:9:26: warning: implicit declaration of function ‘strlen’ [-Wimplicit-function-declaration]
    9 |   char* copydir = malloc(strlen(dir)+1);
      |                          ^~~~~~
../../src/cli/cli.c:3:1: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
    2 | #include "cli.h"
  +++ |+#include <string.h>
    3 | 
../../src/cli/cli.c:9:[26](https://github.com/exercism/wren/actions/runs/6704346582/job/18216581167?pr=137#step:5:27): warning: incompatible implicit declaration of built-in function ‘strlen’ [-Wbuiltin-declaration-mismatch]
    9 |   char* copydir = malloc(strlen(dir)+1);
      |                          ^~~~~~
../../src/cli/cli.c:9:26: note: include ‘<string.h>’ or provide a declaration of ‘strlen’
../../src/cli/cli.c:10:3: warning: implicit declaration of function ‘strcpy’ [-Wimplicit-function-declaration]
   10 |   strcpy(copydir, dir);
      |   ^~~~~~
../../src/cli/cli.c:10:3: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
../../src/cli/cli.c:10:3: warning: incompatible implicit declaration of built-in function ‘strcpy’ [-Wbuiltin-declaration-mismatch]
../../src/cli/cli.c:10:3: note: include ‘<string.h>’ or provide a declaration of ‘strcpy’
```
